### PR TITLE
add anchor IDs to chart headings

### DIFF
--- a/partials/historical_charts.py
+++ b/partials/historical_charts.py
@@ -5,7 +5,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Validator Queue (ETH)</h5>
+		    <h5 class="card-title" id="validator-queue-eth">Validator Queue (ETH)</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("queueChart")}
@@ -19,7 +19,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Queue Wait Time (days)</h5>
+		    <h5 class="card-title" id="queue-wait-time">Queue Wait Time (days)</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("waitChart")}
@@ -33,7 +33,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Active Validators</h5>
+		    <h5 class="card-title" id="active-validators">Active Validators</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("validatorChart")}
@@ -47,7 +47,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Credentials (%)</h5>
+		    <h5 class="card-title" id="credentials-pct">Credentials (%)</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("credentialsPercentChart")}
@@ -61,7 +61,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Credentials (Δ)</h5>
+		    <h5 class="card-title" id="credentials-delta">Credentials (Δ)</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("credentialsDiffChart")}
@@ -75,7 +75,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Supply Staked</h5>
+		    <h5 class="card-title" id="supply-staked">Supply Staked</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("stakedChart")}
@@ -89,7 +89,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title">Staking APR (7d)</h5>
+		    <h5 class="card-title" id="staking-apr">Staking APR (7d)</h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("aprChart")}

--- a/partials/historical_charts.py
+++ b/partials/historical_charts.py
@@ -5,7 +5,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="validator-queue-eth">Validator Queue (ETH)</h5>
+		    <h5 class="card-title" id="validator-queue-eth">Validator Queue (ETH) <a href="#validator-queue-eth" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("queueChart")}
@@ -19,7 +19,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="queue-wait-time">Queue Wait Time (days)</h5>
+		    <h5 class="card-title" id="queue-wait-time">Queue Wait Time (days) <a href="#queue-wait-time" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("waitChart")}
@@ -33,7 +33,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="active-validators">Active Validators</h5>
+		    <h5 class="card-title" id="active-validators">Active Validators <a href="#active-validators" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("validatorChart")}
@@ -47,7 +47,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="credentials-pct">Credentials (%)</h5>
+		    <h5 class="card-title" id="credentials-pct">Credentials (%) <a href="#credentials-pct" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("credentialsPercentChart")}
@@ -61,7 +61,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="credentials-delta">Credentials (Δ)</h5>
+		    <h5 class="card-title" id="credentials-delta">Credentials (Δ) <a href="#credentials-delta" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("credentialsDiffChart")}
@@ -75,7 +75,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="supply-staked">Supply Staked</h5>
+		    <h5 class="card-title" id="supply-staked">Supply Staked <a href="#supply-staked" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("stakedChart")}
@@ -89,7 +89,7 @@ historical_charts = f"""
 
 		<div class="card shadow border-light mt-4">
 		  <div class="card-body">
-		    <h5 class="card-title" id="staking-apr">Staking APR (7d)</h5>
+		    <h5 class="card-title" id="staking-apr">Staking APR (7d) <a href="#staking-apr" class="anchor-link">#</a></h5>
 		    <div class="card-text">
 		    	<div class="text-center text-sm-end">
 			    	{chart_filter("aprChart")}

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -85,3 +85,15 @@ body {
     background-position: center;
 }
 
+.anchor-link {
+    opacity: 0;
+    margin-left: 0.4em;
+    font-size: 0.85em;
+    color: inherit;
+    text-decoration: none;
+    transition: opacity 0.15s;
+}
+
+h5:hover .anchor-link {
+    opacity: 1;
+}


### PR DESCRIPTION
Adds "id" attributes to each chart section heading so charts can be linked to directly, such as "validatorqueue.com/#staking-apr"